### PR TITLE
Restore updated mod metadata

### DIFF
--- a/bg2improvedgui/bg2improvedgui.ini
+++ b/bg2improvedgui/bg2improvedgui.ini
@@ -1,43 +1,39 @@
-# Filename must be the same as tp2 name, placed at the same folder where .tp2 file is present, "UTF8 without BOM" encoding, everything is optional
+# Never copy this file from other mods, always use https://github.com/ALIENQuake/ProjectInfinity/wiki/Adding-metadata-for-mod
+# Filename must be the same as tp2 basename, placed in the same folder where
+# .tp2 file is located, use UTF8 (without BOM) encoding, everything is optional
 
 # ini section header is required to avoid false detection
 [Metadata]
 
-# Full name of the mod, without version number
+# Full name of the mod, without the list of supported games, without the version number, without 'Mod'
 Name = BG2 Improved GUI
 
-# Author name or nick, don't use email address
+# Author name or nick, don't use an email address
 Author = Insomniator
 
 # Short description of the mod, main goals, features etc
-Description = BG2 Improved GUI is a collection of GUI/Sound/Engine improvements and tweaks to make Baldur's Gate 2 more friendly and easy to play
+Description = This mod is a collection of GUI/sound/engine improvements and tweaks to make the original BG2 more friendly and easy to play.
 
-# Web address of mod readme file (filename is case-sensitive!) You can link to txt, md, html, pdf etc.
-Readme = https://spellholdstudios.github.io/BG2_Improved_GUI/bg2improvedgui/documentation/readme.html
+# Web address of mod readme file (filename is case-sensitive!), comma-separated list. You can link to txt, md, html, pdf etc.
+Readme = https://spellhold-studios.github.io/readmes/bg2-improved-gui/documentation/readme.html
 
-#  Web address of mod dedicated forum or forum thread
+# Web address of mod dedicated forum or forum thread 
 Forum = http://www.shsforums.net/topic/60986-bg2-improved-gui/
 
-# Web address of mod Homepage
-Homepage = http://www.shsforums.net/files/file/1265-bg2-improved-gui/
+# Web address of mod personal Homepage, no need to duplicate with a mod dedicated forum
+Homepage = https://spellhold-studios.github.io/
 
-# if you use Github.com, simply use https://github.com/AccountOrOrgName/RepositoryName
+# If you use GitHub.com, simply use https://github.com/AccountOrOrgName/RepositoryName (omit /releases)
 # read more about Delta Updates https://github.com/ALIENQuake/ProjectInfinity/wiki/Delta-Updates-for-mods-hosted-at-Github
-Download = https://github.com/SpellholdStudios/BG2_Improved_GUI
+Download = https://github.com/Spellhold-Studios/BG2-Improved-GUI
 
 # Type of LABELs used by the mod, read more here https://www.gibberlings3.net/forums/topic/32516-tutorial-what-is-label
 LabelType = GloballyUnique
 
 # Dynamic Install Order, use mod ID as tp2 name without file extension and `setup-` prefix
 
-# This mod must be installed *before* the mods listed after the keyword
-Before = item_rev, spell_rev, itemupgrade, BG1TP, TP, cursed_items
+# This mod must be installed *before* those ModID listed below, comma-separated list:
+Before = item_rev, spell_rev, itemupgrade, bg1tp, tp, cursed_items
 
-# This mod must be installed *after* the mods listed after the keyword
-After = TobEx, bg2fixpack, TobEx_AfterLife, widescreen, TutuGUI, GUI_720, 1pp, infinityanimations, bgt
-
-# The listed mods are required to be installed *before* this mod
-Require-Earlier = TobEx
-
-# The listed mods are required to be installed *after* this mod
-# Require-Later =
+# This mod must be installed *after* those ModID listed below, comma-separated list:
+After = tobex, bg2fixpack, tobex_afterlife, widescreen, tutugui, gui_720, 1pp, infinityanimations, bgt


### PR DESCRIPTION
The previously updated mod metadata was overwritten by an older version in https://github.com/Spellhold-Studios/BG2-Improved-GUI/commit/4a478f8169898e6fef37b5483aaf88fa783e8476. This restores the updated version.